### PR TITLE
Check classification result in "make test"

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -15,11 +15,11 @@ ocrd-typegroups-classifier \
     -p <(echo '{"network": "'"$net"'", "stride":143}')
 
 expected_fontfamily='fraktur'
-if ! egrep -q "<pc:TextStyle fontFamily=\"$expected_fontfamily.*" OCR-D-FONTIDENT/OCR-D-FONTIDENT_FILE_0010_DEFAULT; then
+if egrep -q "<pc:TextStyle fontFamily=\"$expected_fontfamily.*" OCR-D-FONTIDENT/OCR-D-FONTIDENT_FILE_0010_DEFAULT; then
+    echo 'Good classification result:'
+    grep '<pc:TextStyle fontFamily=' OCR-D-FONTIDENT/OCR-D-FONTIDENT_FILE_0010_DEFAULT
+else
     echo 'Bad classification result:'
     grep '<pc:TextStyle fontFamily=' OCR-D-FONTIDENT/OCR-D-FONTIDENT_FILE_0010_DEFAULT
     exit 1
-else
-    echo 'Good classification result:'
-    grep '<pc:TextStyle fontFamily=' OCR-D-FONTIDENT/OCR-D-FONTIDENT_FILE_0010_DEFAULT
 fi

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -11,5 +11,15 @@ ocrd-typegroups-classifier \
     -g PHYS_0011 \
     -m mets.xml \
     -I DEFAULT \
-    -O "OCR-D-FONTIDENT" \
+    -O OCR-D-FONTIDENT \
     -p <(echo '{"network": "'"$net"'", "stride":143}')
+
+expected_fontfamily='fraktur'
+if ! egrep -q "<pc:TextStyle fontFamily=\"$expected_fontfamily.*" OCR-D-FONTIDENT/OCR-D-FONTIDENT_FILE_0010_DEFAULT; then
+    echo 'Bad classification result:'
+    grep '<pc:TextStyle fontFamily=' OCR-D-FONTIDENT/OCR-D-FONTIDENT_FILE_0010_DEFAULT
+    exit 1
+else
+    echo 'Good classification result:'
+    grep '<pc:TextStyle fontFamily=' OCR-D-FONTIDENT/OCR-D-FONTIDENT_FILE_0010_DEFAULT
+fi


### PR DESCRIPTION
Make tests/test.sh check the result. As the test itself is written in shell, just use shell ways to check it - instead of actually parsing the XML.

The classification check also assumes that the classification results are sorted by descending probabilities, i.e. that the result with highest probability is listed first.

Fixes #3.