### PR TITLE
🐛 Pass down page id

### DIFF
--- a/ocrd_typegroups_classifier/processor.py
+++ b/ocrd_typegroups_classifier/processor.py
@@ -78,6 +78,7 @@ class TypegroupsClassifierProcessor(Processor):
                 self.workspace.add_file(
                     ID=ID,
                     file_grp=self.output_file_grp,
+                    pageId=input_file.pageId,
                     mimetype=MIMETYPE_PAGE,
                     local_filename="%s/%s" % (self.output_file_grp, ID),
                     content=to_xml(pcgts)


### PR DESCRIPTION
The processor needs to pass down the physical page id, so that results are associated with the page they are inferred from.

Fixes this error, Fixes #10:
~~~
$ ocrd workspace validate --page-strictness lax mets.xml
<report valid="false">
  <!-- ... -->
  <error>File 'OCR-D-FONTIDENT_OCR-D-IMG_00000138' does not manifest any physical page.</error>
  <error>File 'OCR-D-FONTIDENT_OCR-D-IMG_00000139' does not manifest any physical page.</error>
  <error>File 'OCR-D-FONTIDENT_OCR-D-IMG_00000140' does not manifest any physical page.</error>
  <error>File 'OCR-D-FONTIDENT_OCR-D-IMG_00000141' does not manifest any physical page.</error>
  <!-- ... -->
</report>
~~~
