### PR TITLE
:package: update and prune requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
-.
+ocrd >= 2.0.1
+pandas
+scikit-image
+torch >= 1.2.0
+torchvision

--- a/setup.py
+++ b/setup.py
@@ -18,15 +18,7 @@ setup(
     license='Apache License 2.0',
     packages=find_packages(exclude=('tests', 'docs')),
     include_package_data=True,
-    install_requires=[
-        'click',
-        'ocrd >= 1.0.0b7',
-        'pandas',
-        'Pillow == 5.4.1',
-        'scikit-image',
-        'torch >= 1.2.0',
-        'torchvision',
-    ],
+    install_requires=open('requirements.txt').read().split('\n'),
     package_data={
         '': ['*.json', '*.tgc'],
     },


### PR DESCRIPTION
`click` is required by ocrd. Omitting `Pillow` here will fall back to the `Pillow` required by `ocrd` (currently 6.2.0).